### PR TITLE
fixed several problems I encountered

### DIFF
--- a/AppStoreServerApi/Models/JWSTransactionDecodedPayload.cs
+++ b/AppStoreServerApi/Models/JWSTransactionDecodedPayload.cs
@@ -14,7 +14,7 @@ namespace AppStoreServerApi.Models
         /// <summary>
         /// UNIX timestamp in ms
         /// </summary>
-        public int? ExpiresDate { get; set; } = null!;
+        public long? ExpiresDate { get; set; } = null!;
         /// <summary>
         /// see: OwnershipType
         /// </summary>
@@ -25,23 +25,23 @@ namespace AppStoreServerApi.Models
         /// <summary>
         ///  UNIX timestamp in ms
         /// </summary>
-        public int OriginalPurchaseDate { get; set; }
+        public long OriginalPurchaseDate { get; set; }
         public string OriginalTransactionId { get; set; } = null!;
         public string ProductId { get; set; } = null!;
         /// <summary>
         /// UNIX timestamp in ms
         /// </summary>
-        public int PurchaseDate { get; set; } 
+        public long PurchaseDate { get; set; } 
         public int Quantity { get; set; }
         /// <summary>
         /// UNIX timestamp in ms
         /// </summary>
-        public int? RevocationDate { get; set; } = null!;
+        public long? RevocationDate { get; set; } = null!;
         public int? RevocationReason { get; set; } = null!;
         /// <summary>
         /// UNIX timestamp in ms
         /// </summary>
-        public int SignedDate { get; set; } 
+        public long SignedDate { get; set; } 
         public string? SubscriptionGroupIdentifier { get; set; } = null!;
         public string TransactionId { get; set; } = null!;
         /// <summary>


### PR DESCRIPTION
When deserializing into JWSTransactionDecodedPayload, I got an error due to UNIX timestamps being too long for an int property, so I changed them to longs.

In AppleAppstoreClient:
a) In GetToken(), I got an error about the nonce not being able to be created from a Guid, so I changed it to a string.
b) In DecodeJWS<T>(), the X5c property on  JwtSecurityToken.Header was empty, so I used the header dictionary directly.