### PR TITLE
Standard cleanup

### DIFF
--- a/AppStoreServerApi/AppleAppstoreClient.cs
+++ b/AppStoreServerApi/AppleAppstoreClient.cs
@@ -92,6 +92,7 @@ namespace AppStoreServerApi
         }
 
         #region Request utilities
+        
         private async Task<T?> MakeRequest<T>(string url)
         {
             var token = this.GetToken();
@@ -189,6 +190,7 @@ namespace AppStoreServerApi
         #endregion
 
         #region Decode signed fields
+        
         public List<JWSTransactionDecodedPayload> DecodeTransactions(List<string> signedTransactions)
         {
             return signedTransactions.Select(s => DecodeJWS<JWSTransactionDecodedPayload>(s)).ToList();
@@ -276,6 +278,7 @@ namespace AppStoreServerApi
 
             return x509certs;
         }
+        
         #endregion
     }
 }

--- a/AppStoreServerApi/AppleAppstoreClient.cs
+++ b/AppStoreServerApi/AppleAppstoreClient.cs
@@ -142,7 +142,7 @@ namespace AppStoreServerApi
             });
         }
 
-        public ECDsaSecurityKey GetEcdsaSecuritKey()
+        public ECDsaSecurityKey GetEcdsaSecurityKey()
         {
             var signatureAlgorithm = GetEllipticCurveAlgorithm();
             var eCDsaSecurityKey = new ECDsaSecurityKey(signatureAlgorithm)
@@ -163,7 +163,7 @@ namespace AppStoreServerApi
             var now = DateTime.Now;
             var expiry = now.AddSeconds(MaxTokenAge);
 
-            ECDsaSecurityKey eCDsaSecurityKey = GetEcdsaSecuritKey();
+            ECDsaSecurityKey eCDsaSecurityKey = GetEcdsaSecurityKey();
 
             var handler = new JsonWebTokenHandler();
             string jwt = handler.CreateToken(new SecurityTokenDescriptor

--- a/AppStoreServerApi/AppleAppstoreClient.cs
+++ b/AppStoreServerApi/AppleAppstoreClient.cs
@@ -186,11 +186,6 @@ namespace AppStoreServerApi
             return jwt;
         }
 
-        /*private int GetUnixTimestamp(DateTime dateTime)
-        {
-            var time = (dateTime.ToUniversalTime() - new DateTime(1970, 1, 1));
-            return (int)(time.TotalMilliseconds + 0.5);
-        }*/
         #endregion
 
         #region Decode signed fields

--- a/AppStoreServerApi/AppleAppstoreClient.cs
+++ b/AppStoreServerApi/AppleAppstoreClient.cs
@@ -4,7 +4,6 @@ using JWT.Builder;
 using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System.Dynamic;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;

--- a/AppStoreServerApi/Models/AppleEnvironment.cs
+++ b/AppStoreServerApi/Models/AppleEnvironment.cs
@@ -1,5 +1,6 @@
 ﻿namespace AppStoreServerApi.Models
 {
+    // https://developer.apple.com/documentation/appstoreserverapi/environment
     public class AppleEnvironment
     {
         public const string Production = "Production";

--- a/AppStoreServerApi/Models/AppleEnvironment.cs
+++ b/AppStoreServerApi/Models/AppleEnvironment.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public class AppleEnvironment
     {

--- a/AppStoreServerApi/Models/AutoRenewStatus.cs
+++ b/AppStoreServerApi/Models/AutoRenewStatus.cs
@@ -1,6 +1,5 @@
 ﻿namespace AppStoreServerApi.Models
 {
-
     // https://developer.apple.com/documentation/appstoreserverapi/autorenewstatus
     public enum AutoRenewStatus
     {

--- a/AppStoreServerApi/Models/AutoRenewStatus.cs
+++ b/AppStoreServerApi/Models/AutoRenewStatus.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
 
     // https://developer.apple.com/documentation/appstoreserverapi/autorenewstatus

--- a/AppStoreServerApi/Models/CertificateValidationException.cs
+++ b/AppStoreServerApi/Models/CertificateValidationException.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public class CertificateValidationException: Exception
     {

--- a/AppStoreServerApi/Models/DecodedNotificationPayload.cs
+++ b/AppStoreServerApi/Models/DecodedNotificationPayload.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public class DecodedNotificationPayload
     {

--- a/AppStoreServerApi/Models/ExpirationIntent.cs
+++ b/AppStoreServerApi/Models/ExpirationIntent.cs
@@ -1,6 +1,5 @@
 ﻿namespace AppStoreServerApi.Models
 {
-
     // https://developer.apple.com/documentation/appstoreserverapi/expirationintent
     public enum ExpirationIntent
     {

--- a/AppStoreServerApi/Models/ExpirationIntent.cs
+++ b/AppStoreServerApi/Models/ExpirationIntent.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
 
     // https://developer.apple.com/documentation/appstoreserverapi/expirationintent

--- a/AppStoreServerApi/Models/HistoryResponse.cs
+++ b/AppStoreServerApi/Models/HistoryResponse.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/historyresponse
     public class HistoryResponse

--- a/AppStoreServerApi/Models/JWSDecodedHeader.cs
+++ b/AppStoreServerApi/Models/JWSDecodedHeader.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/jwsdecodedheader
     public class JWSDecodedHeader

--- a/AppStoreServerApi/Models/JWSRenewalInfoDecodedPayload.cs
+++ b/AppStoreServerApi/Models/JWSRenewalInfoDecodedPayload.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload
     public class JWSRenewalInfoDecodedPayload

--- a/AppStoreServerApi/Models/JWSTransactionDecodedPayload.cs
+++ b/AppStoreServerApi/Models/JWSTransactionDecodedPayload.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload
     public class JWSTransactionDecodedPayload

--- a/AppStoreServerApi/Models/LastTransactionsItem.cs
+++ b/AppStoreServerApi/Models/LastTransactionsItem.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/lasttransactionsitem
     public class LastTransactionsItem

--- a/AppStoreServerApi/Models/NotificationData.cs
+++ b/AppStoreServerApi/Models/NotificationData.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public class NotificationData
     {

--- a/AppStoreServerApi/Models/NotificationSubtype.cs
+++ b/AppStoreServerApi/Models/NotificationSubtype.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public class NotificationSubtype
     {

--- a/AppStoreServerApi/Models/NotificationType.cs
+++ b/AppStoreServerApi/Models/NotificationType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreservernotifications/notificationtype
     public class NotificationType

--- a/AppStoreServerApi/Models/OfferType.cs
+++ b/AppStoreServerApi/Models/OfferType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/offertype
     public enum OfferType

--- a/AppStoreServerApi/Models/OrderLookupResponse.cs
+++ b/AppStoreServerApi/Models/OrderLookupResponse.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/orderlookupresponse
     public class OrderLookupResponse

--- a/AppStoreServerApi/Models/OrderLookupStatus.cs
+++ b/AppStoreServerApi/Models/OrderLookupStatus.cs
@@ -1,5 +1,6 @@
 ﻿namespace AppStoreServerApi.Models
 {
+    // https://developer.apple.com/documentation/appstoreserverapi/orderlookupstatus
     public enum OrderLookupStatus
     {
         Valid = 0,

--- a/AppStoreServerApi/Models/OrderLookupStatus.cs
+++ b/AppStoreServerApi/Models/OrderLookupStatus.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     public enum OrderLookupStatus
     {

--- a/AppStoreServerApi/Models/OwnershipType.cs
+++ b/AppStoreServerApi/Models/OwnershipType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/inappownershiptype
     public class OwnershipType

--- a/AppStoreServerApi/Models/PriceIncreaseStatus.cs
+++ b/AppStoreServerApi/Models/PriceIncreaseStatus.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/priceincreasestatus
     public enum PriceIncreaseStatus

--- a/AppStoreServerApi/Models/StatusResponse.cs
+++ b/AppStoreServerApi/Models/StatusResponse.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/statusresponse
     public class StatusResponse

--- a/AppStoreServerApi/Models/SubscriptionGroupIdentifierItem.cs
+++ b/AppStoreServerApi/Models/SubscriptionGroupIdentifierItem.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/subscriptiongroupidentifieritem
     public class SubscriptionGroupIdentifierItem

--- a/AppStoreServerApi/Models/SubscriptionStatus.cs
+++ b/AppStoreServerApi/Models/SubscriptionStatus.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/status
     public enum SubscriptionStatus

--- a/AppStoreServerApi/Models/TransactionType.cs
+++ b/AppStoreServerApi/Models/TransactionType.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace AppStoreServerApi.Models
+﻿namespace AppStoreServerApi.Models
 {
     // https://developer.apple.com/documentation/appstoreserverapi/type
     public class TransactionType


### PR DESCRIPTION
Just a quick spritz through the codebase:

- Removing used using directives
- Fixed typo in method name
- Removed commented out code
- Added additional references to the App Store Server API docs. There are a couple more models that don't reference a page in the docs, but I left them as I wasn't sure what they related to or (in the case of NotificationSubtype) [the page](https://developer.apple.com/documentation/appstoreservernotifications/subtype) I figured it was related to didn't line up exactly: 
  - NotificationData
  - NotificationSubtype
  - DecodedNotificationPayload
 - Removed or added whitespace where appropriate